### PR TITLE
android support for cocos2dx without ssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ build/
 .tags_sorted_by_file
 **xcodeproj/
 **dSYM/
-*.mk
 gyp-mac-tool
 pomelo.Makefile
 deps/jansson/jansson.Makefile

--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,49 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := pomelo_static
+
+LOCAL_MODULE_FILENAME := libpomelo
+
+LOCAL_SRC_FILES := \
+src/pc_lib.c \
+src/pc_pomelo.c \
+src/pc_trans.c \
+src/pc_trans_repo.c \
+src/tr/dummy/tr_dummy.c \
+src/tr/uv/pb_decode.c \
+src/tr/uv/pb_encode.c \
+src/tr/uv/pb_util.c \
+src/tr/uv/pr_msg.c \
+src/tr/uv/pr_msg_json.c \
+src/tr/uv/pr_msg_pb.c \
+src/tr/uv/pr_pkg.c \
+src/tr/uv/tr_uv_tcp.c \
+src/tr/uv/tr_uv_tcp_aux.c \
+src/tr/uv/tr_uv_tcp_i.c
+
+
+LOCAL_CFLAGS := -DPC_NO_UV_TLS_TRANS
+
+
+
+LOCAL_EXPORT_C_INCLUDES :=$(LOCAL_PATH)/include
+
+
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/include \
+                    $(LOCAL_PATH)/src \
+					$(LOCAL_PATH)/src/tr/dummy \
+					$(LOCAL_PATH)/src/tr/uv
+
+LOCAL_WHOLE_STATIC_LIBRARIES := uv_static jansson_static
+
+
+
+include $(BUILD_STATIC_LIBRARY)
+
+LOCAL_CFLAGS    := -D__ANDROID__ 
+
+$(call import-module,libpomelo2/deps/uv) \
+$(call import-module,libpomelo2/deps/jansson)

--- a/android-compile.sh
+++ b/android-compile.sh
@@ -30,5 +30,5 @@ export CXX=arm-linux-androideabi-g++
 export LINK=arm-linux-androideabi-g++
 export PLATFORM=android
 
-gyp --depth=. -Dtarget_arch=arm -DOS=android -Dpomelo_library=static_library -Duse_sys_openssl=false -Dbuild_jpomelo=true $SSL pomelo.gyp
+gyp --depth=. -Dtarget_arch=arm -DOS=android -Dpomelo_library=static_library -Duse_sys_openssl=false -Dbuild_jpomelo=true $SSL pomelo.gyp --format=make
 

--- a/android-gen.sh
+++ b/android-gen.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+export ANDROID_TOOLCHAIN_DIR=$PWD/android-toolchain
 export PATH=$ANDROID_TOOLCHAIN_DIR/bin:$PATH
 export AR=arm-linux-androideabi-ar
 export CC=arm-linux-androideabi-gcc
@@ -7,4 +8,4 @@ export CXX=arm-linux-androideabi-g++
 export LINK=arm-linux-androideabi-g++
 export PLATFORM=android
 
-gyp --depth=. -Dtarget_arch=arm -DOS=android -Dpomelo_library=static_library -Duse_sys_openssl=false -Dbuild_jpomelo=true
+gyp --depth=. -Dtarget_arch=arm -DOS=android -Dpomelo_library=static_library -Duse_sys_openssl=false -Dbuild_jpomelo=true pomelo.gyp --format=make

--- a/deps/jansson/Android.mk
+++ b/deps/jansson/Android.mk
@@ -1,0 +1,37 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := jansson_static
+
+LOCAL_MODULE_FILENAME := libjansson
+
+LOCAL_SRC_FILES := \
+src/dump.c \
+src/error.c \
+src/hashtable.c \
+src/hashtable_seed.c \
+src/load.c \
+src/memory.c \
+src/pack_unpack.c \
+src/strbuffer.c \
+src/strconv.c \
+src/utf.c \
+src/value.c
+
+
+LOCAL_CFLAGS := -DHAVE_STDINT_H \
+				   -DVALGRIND
+
+
+LOCAL_EXPORT_C_INCLUDES :=$(LOCAL_PATH)/src
+
+
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH) \
+                    $(LOCAL_PATH)/src
+
+
+include $(BUILD_STATIC_LIBRARY)
+
+

--- a/deps/uv/Android.mk
+++ b/deps/uv/Android.mk
@@ -1,0 +1,55 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := uv_static
+
+LOCAL_MODULE_FILENAME := libuv
+
+LOCAL_SRC_FILES := \
+src/fs-poll.c \
+src/inet.c \
+src/threadpool.c \
+src/unix/async.c \
+src/unix/core.c \
+src/unix/dl.c \
+src/unix/fs.c \
+src/unix/getaddrinfo.c \
+src/unix/getnameinfo.c \
+src/unix/linux-core.c \
+src/unix/linux-inotify.c \
+src/unix/linux-syscalls.c \
+src/unix/loop-watcher.c \
+src/unix/loop.c \
+src/unix/pipe.c \
+src/unix/poll.c \
+src/unix/process.c \
+src/unix/proctitle.c \
+src/unix/pthread-fixes.c \
+src/unix/signal.c \
+src/unix/stream.c \
+src/unix/tcp.c \
+src/unix/thread.c \
+src/unix/timer.c \
+src/unix/tty.c \
+src/unix/udp.c \
+src/uv-common.c \
+src/version.c
+
+
+
+LOCAL_EXPORT_C_INCLUDES :=$(LOCAL_PATH)/include
+
+
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH) \
+                    $(LOCAL_PATH)/include \
+                    $(LOCAL_PATH)/src \
+					$(LOCAL_PATH)/src/unix
+
+LOCAL_LDLIBS := -lm \
+				-ldl
+
+include $(BUILD_STATIC_LIBRARY)
+
+


### PR DESCRIPTION
android-compile脚本在macosx系统下实在搞不定，参考gyp和libpomelo中得Android.mk做了libpomelo2的Android.mk，已经测试集成通过。

不过有2个问题：
- 由于我们的项目不需要ssl，所以没有做ssl的支持
- 由于是针对cocos2dx项目，所以libuv没有编译`android-ifaddrs.c`文件，因为在cocos2dx带的libwebsockets里面已经带了相关的函数定义，加进来的话，编译无法通过。非cocos2dx项目可能需要加入这个文件。
