### PR TITLE
Add instructions for installing gyp

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,14 @@ libpomelo2
 
 ### How to compile 
 
-#### gyp
+#### Install [gyp](https://gyp.gsrc.io/)
+```
+git clone https://chromium.googlesource.com/external/gyp
+cd gyp
+python setup.py install
+ 
+```
+#### Generate native IDE project files by [gyp](https://gyp.gsrc.io/)
 
     $ gyp --depth=. pomelo.gyp [options]
 


### PR DESCRIPTION
Add instructions for installing gyp , for someone like me first time using gyp.

When google `install gyp` , the most result is node-gyp, so it make sense to have some guide for  installing gyp.