### PR TITLE
remove duplicated close code in `tcp__cleanup_async_cb`.

### DIFF
--- a/src/tr/uv/tr_uv_tcp_aux.c
+++ b/src/tr/uv/tr_uv_tcp_aux.c
@@ -658,10 +658,6 @@ void tcp__cleanup_async_cb(uv_async_t* a)
     }
 
     tcp__cleanup_pc_json(&tt->handshake_opts);
-
-    if (!uv_is_closing((uv_handle_t*)&tt->socket)) {
-        uv_close((uv_handle_t*)&tt->socket, NULL);
-    }
     tt->reconn_times = 0;
 
 #define C(x) uv_close((uv_handle_t*)&tt->x, NULL)


### PR DESCRIPTION
`tt->reset_fn(tt)` aka `tcp__reset` already closed the tcp handle.