### PR TITLE
Fires timeout error only when connecting is canceled by timeout.

### DIFF
--- a/src/tr/uv/tr_uv_tcp_aux.c
+++ b/src/tr/uv/tr_uv_tcp_aux.c
@@ -347,8 +347,10 @@ void tcp__conn_done_cb(uv_connect_t* conn, int status)
     }
 
     if (status == UV_ECANCELED) {
-        pc_lib_log(PC_LOG_DEBUG, "tcp__conn_done_cb - connect timeout");
-        pc_trans_fire_event(tt->client, PC_EV_CONNECT_ERROR, "Connect Timeout", NULL);
+        if (tt->client->state != PC_ST_INITED) { // not disconnected by user, so it's timeout.
+            pc_lib_log(PC_LOG_DEBUG, "tcp__conn_done_cb - connect timeout");
+            pc_trans_fire_event(tt->client, PC_EV_CONNECT_ERROR, "Connect Timeout", NULL);
+        }
     } else {
         pc_lib_log(PC_LOG_DEBUG, "tcp__conn_done_cb - connect error, error: %s", uv_strerror(status));
         pc_trans_fire_event(tt->client, PC_EV_CONNECT_ERROR, "Connect Error", NULL);


### PR DESCRIPTION
This fixes follow usage:
1. pc_client_connect() start an async connecting request.
2. call pc_client_disconnect() immediately, fires PC_EV_DISCONNECT, and set client->state to PC_ST_INITED.
3. tcp__conn_done_cb() called with status == UV_ECANCELED, which fires PC_EV_CONNECT_ERROR.
4. pc__trans_fire_event() check clinet->state for PC_EV_CONNECT_ERROR, the assertion assert(client->state == PC_ST_CONNECTING || client->state == PC_ST_DISCONNECTING) fails.