### PR TITLE
Refactor pc_tranc.c

### DIFF
--- a/src/pc_pomelo.c
+++ b/src/pc_pomelo.c
@@ -307,18 +307,18 @@ static void pc__handle_event(pc_client_t* client, pc_event_t* ev)
     assert(PC_EV_IS_RESP(ev->type) || PC_EV_IS_NOTIFY_SENT(ev->type) || PC_EV_IS_NET_EVENT(ev->type));
 
     if (PC_EV_IS_RESP(ev->type)) {
-        pc__trans_resp(client, ev->data.req.req_id, ev->data.req.rc, ev->data.req.resp, 0/* not pending */);
+        pc__trans_resp(client, ev->data.req.req_id, ev->data.req.rc, ev->data.req.resp);
         pc_lib_log(PC_LOG_DEBUG, "pc__handle_event - fire pending trans resp, req_id: %u, rc: %s",
                 ev->data.req.req_id, pc_client_rc_str(ev->data.req.rc));
         pc_lib_free((char* )ev->data.req.resp);
         ev->data.req.resp = NULL;
 
     } else if (PC_EV_IS_NOTIFY_SENT(ev->type)) {
-        pc__trans_sent(client, ev->data.notify.seq_num, ev->data.notify.rc, 0/* not pending */);
+        pc__trans_sent(client, ev->data.notify.seq_num, ev->data.notify.rc);
         pc_lib_log(PC_LOG_DEBUG, "pc__handle_event - fire pending trans sent, seq_num: %u, rc: %s",
                 ev->data.notify.seq_num, pc_client_rc_str(ev->data.notify.rc));
     } else {
-        pc__trans_fire_event(client, ev->data.ev.ev_type, ev->data.ev.arg1, ev->data.ev.arg2, 0/* not pending */);
+        pc__trans_fire_event(client, ev->data.ev.ev_type, ev->data.ev.arg1, ev->data.ev.arg2);
         pc_lib_log(PC_LOG_DEBUG, "pc__handle_event - fire pending trans event: %s, arg1: %s",
                 pc_client_ev_str(ev->data.ev.ev_type), ev->data.ev.arg1 ? ev->data.ev.arg1 : "");
         pc_lib_free((char* )ev->data.ev.arg1);

--- a/src/pc_pomelo_i.h
+++ b/src/pc_pomelo_i.h
@@ -142,9 +142,9 @@ struct pc_client_s {
     int is_in_poll;
 };
 
-void pc__trans_resp(pc_client_t* client, unsigned int req_id, int rc, const char* resp, int pending);
-void pc__trans_sent(pc_client_t* client, unsigned int req_num, int rc, int pending);
-void pc__trans_fire_event(pc_client_t* client, int ev_type, const char* arg1, const char* arg2, int pending);
+void pc__trans_resp(pc_client_t* client, unsigned int req_id, int rc, const char* resp);
+void pc__trans_sent(pc_client_t* client, unsigned int req_num, int rc);
+void pc__trans_fire_event(pc_client_t* client, int ev_type, const char* arg1, const char* arg2);
 
 #endif /* PC_POMELO_I_H */
 


### PR DESCRIPTION
1. split sync and async code in `pc_tranc.c` into different functions.
2. `pc__trans_resp`, `pc__trans_sent` and `pc__trans_fire_event` will not queue items, the `pending` arg has removed.
3. do state change in  `pc_trans_fire_event`, that is when event occurs, the state is changed not when the event is dispatched. ( this shuld fixes #60 )
4. using a simple state machine for state translate code in `pc_trans_fire_event`.

TODO:   remove extra indent for code marked with  `// follow code has extra indent for better git diff in pull request.` after the pr is merged.